### PR TITLE
Add "static", "hover" and "colors" as parameters to `show`

### DIFF
--- a/henchman/plotting.py
+++ b/henchman/plotting.py
@@ -193,11 +193,15 @@ def piechart(col, sort=True, mergepast=None, drop_n=None, figargs=None):
 
     def modify_doc(doc, col, sort, mergepast, drop_n, figargs):
         def callback(attr, old, new):
-            source.data = ColumnDataSource(
-                _make_piechart_source(col,
-                                      sort=sorted_button.active,
-                                      mergepast=merge_slider.value,
-                                      drop_n=drop_slider.value)).data
+            try:
+                source.data = ColumnDataSource(
+                    _make_piechart_source(col,
+                                          sort=sorted_button.active,
+                                          mergepast=merge_slider.value,
+                                          drop_n=drop_slider.value,
+                                          figargs=figargs)).data
+            except Exception as e:
+                print(e)
 
         sorted_button, merge_slider, drop_slider = _piechart_widgets(
             col, sort, mergepast, drop_n, callback)
@@ -251,9 +255,12 @@ def histogram(col, y=None, n_bins=10, col_max=None, col_min=None,
 
     def modify_doc(doc, col, y, n_bins, col_max, col_min, normalized, figargs):
         def callback(attr, old, new):
-            source.data = ColumnDataSource(_make_histogram_source(
-                col, y, n_bins=slider.value, col_max=range_select.value[1],
-                col_min=range_select.value[0], normalized=normalized)).data
+            try:
+                source.data = ColumnDataSource(_make_histogram_source(
+                    col, y, n_bins=slider.value, col_max=range_select.value[1],
+                    col_min=range_select.value[0], normalized=normalized)).data
+            except Exception as e:
+                print(e)
 
         slider, range_select = _histogram_widgets(col, y, n_bins, col_max, col_min, callback)
 
@@ -361,9 +368,13 @@ def scatter(col_1, col_2, agg=None, label=None, aggregate='last',
 
     def modify_doc(doc, col_1, col_2, agg, label, aggregate, figargs):
         def callback(attr, old, new):
-            source.data = ColumnDataSource(
-                _make_scatter_source(col_1, col_2, agg, label, aggregate=dropdown.value)).data
-            dropdown.label = dropdown.value
+            try:
+                source.data = ColumnDataSource(
+                    _make_scatter_source(col_1, col_2, agg, label, aggregate=dropdown.value)).data
+                dropdown.label = dropdown.value
+            except Exception as e:
+                print(e)
+
         dropdown = _scatter_widgets(col_1, col_2, aggregate, callback)
         if agg is not None:
             doc.add_root(column(dropdown, plot))
@@ -544,14 +555,17 @@ def dendrogram(D, figargs=None):
                                height=50, width=400)
 
         def callback(attr, old, new):
-            edges = D.edges[slider.value]
-            edges_source.data = ColumnDataSource(
-                pd.DataFrame(edges).rename(columns={1: 'end',
-                                                    0: 'start'})).data
-            step_source.data = ColumnDataSource(
-                {'step': [slider.value],
-                 'thresh': [D.threshlist[slider.value]],
-                 'components': [len(D.graphs[slider.value])]}).data
+            try:
+                edges = D.edges[slider.value]
+                edges_source.data = ColumnDataSource(
+                    pd.DataFrame(edges).rename(columns={1: 'end',
+                                                        0: 'start'})).data
+                step_source.data = ColumnDataSource(
+                    {'step': [slider.value],
+                     'thresh': [D.threshlist[slider.value]],
+                     'components': [len(D.graphs[slider.value])]}).data
+            except Exception as e:
+                print(e)
 
         slider = Slider(start=0,
                         end=len(D.edges),

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -149,3 +149,16 @@ def test_modify_plot(fm):
                width=300, height=300, title='Distance Histogram',
                x_axis='axis x', y_axis='axis y',
                x_range=(0, 1000), y_range=(0, 1000))
+
+
+def test_color(fm):
+    colors = ['white', '#000000', 'green']
+    hplot.show(hplot.histogram(fm['flights.distance_group']), colors=colors)
+    hplot.show(hplot.piechart(fm['flights.dest']), colors=colors)
+    hplot.show(hplot.scatter(fm['distance'], fm['distance']), colors=colors)
+
+    fm_with_time = fm.reset_index()
+    fm_with_time['time'] = pd.to_datetime(fm_with_time['time'])
+    col_1 = fm_with_time['time']
+    col_2 = fm_with_time['label']
+    hplot.show(hplot.timeseries(col_1, col_2), colors=colors)


### PR DESCRIPTION
close #4

### Status
Check the following boxes when they are accurate.

- [x] I have rebased onto the most recent version of master
- [x] I have written new tests for any functionality I added
- [x] This code is no longer a work in progress and is ready for review.

### Description
This PR is an API update which moves `static` and `hover` into `figargs` instead of having them as a keyword argument in every function. We also add the `colors` figure argument which is a list of colors, some of which will be used depending on the function in question.

While the previous API would have done
```
show(hplot.timeseries(X['python_version'], static=True, hover=False))
```

the new API puts figure level properties after the parentheses:
```
show(hplot.timeseries(X['python_version']), static=True, hover=False)
```

- [x] add colors, static and hover to figargs
- [x] modify the input to `histogram`, `scatter`, `piechart` and `timeseries`
- [x] force static plot when returning a png image
- [x] update plotting tests
- [x] add try/catch for the dynamic plot callbacks
- [x] increase size of scatter dots
- [x] write new tests for color functionality
