### PR TITLE
Add a lineplot

### DIFF
--- a/docs/_source/api_ref.rst
+++ b/docs/_source/api_ref.rst
@@ -65,6 +65,7 @@ Plotting API
     histogram
     timeseries
     scatter
+    lineplot
     dendrogram
     feature_importances
     roc_auc

--- a/docs/_source/documentation.rst
+++ b/docs/_source/documentation.rst
@@ -222,6 +222,7 @@ for some example bokeh plots.
     histogram
     timeseries
     scatter
+    lineplot
     dendrogram
     feature_importances
     roc_auc

--- a/henchman/plotting.py
+++ b/henchman/plotting.py
@@ -9,6 +9,7 @@ Contents:
         histogram
         scatter
         timeseries
+        lineplot
         dendrogram
         feature_importances
 '''
@@ -1073,8 +1074,3 @@ def _lineplot_widgets(col_1, col_2, samples, callback):
     slider = Slider(start=1, end=col_1.shape[0], value=samples, title='Samples')
     slider.on_change('value', callback)
     return slider
-
-
-show(lineplot(cumulative['x'], cumulative['index'], col_1_names=cumulative.index, samples=None),
-     hover=True, height=400, static=False, x_range=(0, 341),
-     title='Downloads by Days since September 27', y_axis='Cumulative Downloads', x_axis='Days since Release')

--- a/henchman/plotting.py
+++ b/henchman/plotting.py
@@ -415,6 +415,53 @@ def scatter(col_1, col_2, cat=None, label=None, aggregate='last',
     return lambda doc: modify_doc(doc, col_1, col_2, cat, label, aggregate, figargs)
 
 
+def lineplot(col_1, col_2, col_1_names=None, col_2_names=None, label=None, samples=None,
+             figargs=None):
+    '''Creates a line plot of two variables.
+    This function allows for the display of two variables with
+    optional arguments to smooth the graph and add non-numeric axis labels.
+    A standard example would be to look at
+    the "last" row for a column that's changing over time.
+
+    Args:
+        col_1 (pd.Series): The x-values of the line.
+        col_2 (pd.Series): The y-values of the line.
+        col_1_names (pd.Series, optional): Names for the x axis.
+        col_2_names (pd.Series, optional): Names for the y axis
+        label (pd.Series, optional): A numeric label to be used in the hovertool.
+        samples (int): The number of evenly spaced samples to take of the dataframe.
+
+    Example:
+        If the dataframe ``X`` has an integer ``time`` and ``quantity``.
+
+        >>> import henchman.plotting as hplot
+        >>> plot = hplot.lineplot(X['time'], X['quantity'], col_1_names=pd.to_datetime(X['time']))
+        >>> hplot.show(plot)
+
+    '''
+    if figargs is None:
+        return lambda figargs: lineplot(
+            col_1, col_2, col_1_names, col_2_names, label, samples, figargs=figargs)
+    source = ColumnDataSource(_make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples))
+    plot = _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, figargs)
+    plot = _modify_plot(plot, figargs)
+
+    if figargs['static']:
+        return plot
+
+    def modify_doc(doc, col_1, col_2, col_1_names, col_2_names, label, samples, figargs):
+        def callback(attr, old, new):
+            try:
+                source.data = ColumnDataSource(
+                    _make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples=slider.value)).data
+            except Exception as e:
+                print(e)
+
+        slider = _lineplot_widgets(col_1, col_2, samples, callback)
+        doc.add_root(column(slider, plot))
+    return lambda doc: modify_doc(doc, col_1, col_2, col_1_names, col_2_names, label, samples, figargs)
+
+
 def feature_importances(X, model, n_feats=5, figargs=None):
     '''Plot feature importances.
 
@@ -966,3 +1013,68 @@ def _scatter_widgets(col_1, col_2, aggregate, callback):
                               ('min', 'min')])
     dropdown.on_change('value', callback)
     return dropdown
+
+
+def _make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples):
+    tmp = pd.DataFrame({'col_1': col_1, 'col_2': col_2})
+
+    if label is not None:
+        tmp['label'] = label
+    if col_1_names is None:
+        col_1_names = col_1.astype(str)
+    if col_2_names is None:
+        col_2_names = col_2.astype(str)
+
+    tmp['col_1_names'] = col_1_names
+    tmp['col_2_names'] = col_2_names
+    assert col_1_names.shape[0] == tmp.shape[0]
+    assert col_2_names.shape[0] == tmp.shape[0]
+
+    if samples is not None:
+        size = tmp.shape[0] / float(samples)
+        tmp['segment'] = [np.floor(i / size) for i in range(tmp.shape[0])]
+        tmp = tmp.groupby('segment').head(1)
+
+    return tmp
+
+
+def _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, figargs):
+    tools = ['box_zoom', 'save', 'reset']
+    if figargs['hover']:
+        hover = HoverTool(tooltips=[
+            (col_1.name, ' @col_1'),
+            (col_2.name, ' @col_2'),
+        ])
+        if label is not None:
+            hover.tooltips += [('label', ' @label')]
+
+        tools += [hover]
+
+    plot = figure(tools=tools)
+    if figargs['colors'] is not None:
+        line_color = figargs['colors'][0]
+    else:
+        line_color = '#1F77B4'
+    plot.line(x='col_1',
+              y='col_2',
+              color=line_color,
+              source=source,
+              alpha=.8)
+    if col_1_names is not None:
+        plot.xaxis.major_label_overrides = {str(x): str(col_1_names[i]) for i, x in enumerate(col_1)}
+    if col_2_names is not None:
+        plot.yaxis.major_label_overrides = {str(x): str(col_2_names[i]) for i, x in enumerate(col_2)}
+    return plot
+
+
+def _lineplot_widgets(col_1, col_2, samples, callback):
+    if samples is None:
+        samples = col_1.shape[0]
+    slider = Slider(start=1, end=col_1.shape[0], value=samples, title='Samples')
+    slider.on_change('value', callback)
+    return slider
+
+
+show(lineplot(cumulative['x'], cumulative['index'], col_1_names=cumulative.index, samples=None),
+     hover=True, height=400, static=False, x_range=(0, 341),
+     title='Downloads by Days since September 27', y_axis='Cumulative Downloads', x_axis='Days since Release')

--- a/henchman/plotting.py
+++ b/henchman/plotting.py
@@ -416,7 +416,7 @@ def scatter(col_1, col_2, cat=None, label=None, aggregate='last',
     return lambda doc: modify_doc(doc, col_1, col_2, cat, label, aggregate, figargs)
 
 
-def lineplot(col_1, col_2, col_1_names=None, col_2_names=None, label=None, samples=None,
+def lineplot(col_1, col_2, label=None, samples=None,
              figargs=None):
     '''Creates a line plot of two variables.
     This function allows for the display of two variables with
@@ -427,8 +427,6 @@ def lineplot(col_1, col_2, col_1_names=None, col_2_names=None, label=None, sampl
     Args:
         col_1 (pd.Series): The x-values of the line.
         col_2 (pd.Series): The y-values of the line.
-        col_1_names (pd.Series, optional): Names for the x axis.
-        col_2_names (pd.Series, optional): Names for the y axis
         label (pd.Series, optional): A numeric label to be used in the hovertool.
         samples (int): The number of evenly spaced samples to take of the dataframe.
 
@@ -436,31 +434,31 @@ def lineplot(col_1, col_2, col_1_names=None, col_2_names=None, label=None, sampl
         If the dataframe ``X`` has an integer ``time`` and ``quantity``.
 
         >>> import henchman.plotting as hplot
-        >>> plot = hplot.lineplot(X['time'], X['quantity'], col_1_names=pd.to_datetime(X['time']))
+        >>> plot = hplot.scatter(X['time'], X['quantity'], col_1_names=pd.to_datetime(X['time']))
         >>> hplot.show(plot)
 
     '''
     if figargs is None:
         return lambda figargs: lineplot(
-            col_1, col_2, col_1_names, col_2_names, label, samples, figargs=figargs)
-    source = ColumnDataSource(_make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples))
-    plot = _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, figargs)
+            col_1, col_2, label, samples, figargs=figargs)
+    source = ColumnDataSource(_make_lineplot_source(col_1, col_2, label, samples))
+    plot = _make_lineplot_plot(col_1, col_2, label, source, figargs)
     plot = _modify_plot(plot, figargs)
 
     if figargs['static']:
         return plot
 
-    def modify_doc(doc, col_1, col_2, col_1_names, col_2_names, label, samples, figargs):
+    def modify_doc(doc, col_1, col_2,  label, samples, figargs):
         def callback(attr, old, new):
             try:
                 source.data = ColumnDataSource(
-                    _make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples=slider.value)).data
+                    _make_lineplot_source(col_1, col_2, label, samples=slider.value)).data
             except Exception as e:
                 print(e)
 
         slider = _lineplot_widgets(col_1, col_2, samples, callback)
         doc.add_root(column(slider, plot))
-    return lambda doc: modify_doc(doc, col_1, col_2, col_1_names, col_2_names, label, samples, figargs)
+    return lambda doc: modify_doc(doc, col_1, col_2, label, samples, figargs)
 
 
 def feature_importances(X, model, n_feats=5, figargs=None):
@@ -1016,20 +1014,11 @@ def _scatter_widgets(col_1, col_2, aggregate, callback):
     return dropdown
 
 
-def _make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples):
+def _make_lineplot_source(col_1, col_2, label, samples):
     tmp = pd.DataFrame({'col_1': col_1, 'col_2': col_2})
 
     if label is not None:
         tmp['label'] = label
-    if col_1_names is None:
-        col_1_names = col_1.astype(str)
-    if col_2_names is None:
-        col_2_names = col_2.astype(str)
-
-    tmp['col_1_names'] = col_1_names
-    tmp['col_2_names'] = col_2_names
-    assert col_1_names.shape[0] == tmp.shape[0]
-    assert col_2_names.shape[0] == tmp.shape[0]
 
     if samples is not None:
         size = tmp.shape[0] / float(samples)
@@ -1039,7 +1028,7 @@ def _make_lineplot_source(col_1, col_2, col_1_names, col_2_names, label, samples
     return tmp
 
 
-def _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, figargs):
+def _make_lineplot_plot(col_1, col_2, label, source, figargs):
     tools = ['box_zoom', 'save', 'reset']
     if figargs['hover']:
         hover = HoverTool(tooltips=[
@@ -1050,8 +1039,10 @@ def _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, f
             hover.tooltips += [('label', ' @label')]
 
         tools += [hover]
+    tools = []
 
     plot = figure(tools=tools)
+    plot.toolbar.logo = None
     if figargs['colors'] is not None:
         line_color = figargs['colors'][0]
     else:
@@ -1060,11 +1051,8 @@ def _make_lineplot_plot(col_1, col_2, col_1_names, col_2_names, label, source, f
               y='col_2',
               color=line_color,
               source=source,
+              line_width=4,
               alpha=.8)
-    if col_1_names is not None:
-        plot.xaxis.major_label_overrides = {str(x): str(col_1_names[i]) for i, x in enumerate(col_1)}
-    if col_2_names is not None:
-        plot.yaxis.major_label_overrides = {str(x): str(col_2_names[i]) for i, x in enumerate(col_2)}
     return plot
 
 
@@ -1074,3 +1062,17 @@ def _lineplot_widgets(col_1, col_2, samples, callback):
     slider = Slider(start=1, end=col_1.shape[0], value=samples, title='Samples')
     slider.on_change('value', callback)
     return slider
+
+
+filtered = data[data['timestamp'] > pd.to_datetime('2017-8-1')]
+filtered = filtered.sort_values(by='timestamp')
+filtered['date'] = filtered['timestamp'].dt.date
+cumulative = filtered.groupby('date').count()[['index']].cumsum()
+cumulative['Day'] = [i for i in range(cumulative.shape[0])]
+
+cumulative = cumulative.rename(columns={'index': 'Downloads'})
+
+
+show(lineplot(cumulative['Day'], cumulative['Downloads'], samples=60),
+     hover=True, height=400, width=800, static=False,
+     title='Downloads to Date', y_axis='Cumulative Downloads', x_axis='Date')


### PR DESCRIPTION
close #36 

### Status
Check the following boxes when they are accurate.

- [ ] I have rebased onto the most recent version of master
- [ ] I have written new tests for any functionality I added
- [ ] This code is no longer a work in progress and is ready for review.


### Description
A lineplot is a scatterplot variant where you expect to see the data in a particular order, and the value at `x+1` is related to the value at `x`. There are a couple of interesting attributes of line plots, which seem to be difficult to handle. Here's the working list:

- [x] Create a sample `henchman.plotting.lineplot` function
- [x] Allow for a `sample` slider, which downsamples the points resulting in a smoother graph
- [x] Add a docstring for `lineplot` and a link in the documentation and api reference
- [ ] Add tests for `lineplot`
- [ ] Handle categorical labels on the x and y axis
    + This is difficult for two reasons
        1. There's not an col_names for every possible float axis labels (which are autogenerated by bokeh)
        2. There's not necessarily an axis label to replace for the relevant col_names
   + Both can be handled with `FixedTicker(ticks=valueslist)`, but then it's necessary to find how many values are appropriate. That seems to be a hard problem.
- [ ] Handle multiple lineplots using the same axes (this is an API question)
- [ ] Give the ability to show rate of change, area under curve
- [ ] Add an example in the plotting gallery

Given all of those, I'm going to increase the difficulty of the tagged issue.
